### PR TITLE
Allow for custom paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ You must be using either Valet or Herd for your local development environment:
 - Laravel Valet v4+
 - Laravel Herd
 
-**_⚠️ This also assumes that the root of the repo of your local WordPress website is sat inside `/public` and assumes that WordPress Core is installed inside `/public/wp/`. If this is not the case, then this will likely not work and the driver will need further modification._**
-
 ## Installation
 Grab the `WordPressMultisiteSubdirectoryValetDriver.php` file from here.
 
@@ -19,6 +17,15 @@ Place the file in the following directory `~/Library/Application Support/Herd/co
 
 ### For Valet Users
 Place the file in the following directory `~/.config/valet/Drivers` and let the magic do its thing. It's probably best to restart Valet.
+
+## Configuration
+Out of the box, this should support vanilla WordPress multisites that have no custom configuration. However there may be a requirement that your site's public path (relative to the root of the site in Valet or Herd) is in a different directory than usual (e.g. in /public). There may also be a requirement whereby the WordPress Core files are installed in a separate directory as well (e.g. in /public/wp).
+
+If this is the case then please modify the values of `$wpCoreRootPath` and `$rootSitePAth` public attributes.
+
+`$wpCoreRootPath` specifies the path to the WordPress core directory relative to the root of the Valet or Herd site path. For example, a default/vanilla install of WordPress, this should be left as a `/`. But if your WordPress Core files are location in a different directory, then specify it here, e.g. `/public/wp`.
+
+`$rootSitePAth` specifies the public path of your website relative to the root of the Valet or Herd site path. For example, a default/vanilla install of WordPress in Herd or Valet, this should be left as a `/`. But if your public files are located in a different directory, then specify it here, e.g. `/public`.
 
 ## License
 This project is licensed under the MIT License. See the [LICENSE.md](./LICENSE.md) file for more details.

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Place the file in the following directory `~/.config/valet/Drivers` and let the 
 ## Configuration
 Out of the box, this should support vanilla WordPress multisites that have no custom configuration. However there may be a requirement that your site's public path (relative to the root of the site in Valet or Herd) is in a different directory than usual (e.g. in /public). There may also be a requirement whereby the WordPress Core files are installed in a separate directory as well (e.g. in /public/wp).
 
-If this is the case then please modify the values of `$wpCoreRootPath` and `$rootSitePAth` public attributes.
+If this is the case then please modify the values of `$wpCoreRootPath` and `$rootSitePath` public attributes.
 
-`$wpCoreRootPath` specifies the path to the WordPress core directory relative to the root of the Valet or Herd site path. For example, a default/vanilla install of WordPress, this should be left as a `/`. But if your WordPress Core files are location in a different directory, then specify it here, e.g. `/public/wp`.
+`$wpCoreRootPath` specifies the path to the WordPress Core directory relative to the root of the Valet or Herd site path. For example, a default/vanilla install of WordPress, this should be left as a `/`. But if your WordPress Core files are location in a different directory, then specify it here, e.g. `/public/wp`.
 
-`$rootSitePAth` specifies the public path of your website relative to the root of the Valet or Herd site path. For example, a default/vanilla install of WordPress in Herd or Valet, this should be left as a `/`. But if your public files are located in a different directory, then specify it here, e.g. `/public`.
+`$rootSitePath` specifies the public path of your website relative to the root of the Valet or Herd site path. For example, a default/vanilla install of WordPress in Herd or Valet, this should be left as a `/`. But if your public files are located in a different directory, then specify it here, e.g. `/public`.
 
 ## License
 This project is licensed under the MIT License. See the [LICENSE.md](./LICENSE.md) file for more details.

--- a/WordPressMultisiteSubdirectoryValetDriver.php
+++ b/WordPressMultisiteSubdirectoryValetDriver.php
@@ -6,21 +6,31 @@ use Valet\Drivers\BasicWithPublicValetDriver;
 
 class WordPressMultisiteSubdirectoryValetDriver extends BasicWithPublicValetDriver
 {
-    public $wp_root = "wp"; // "wp"
+    /**
+     *  Specifies the path to the WordPress core directory relative to the root of the Valet or Herd site path.
+     *  For example, a default/vanilla install of WordPress, this should be left as a "/". But if your WordPress Core files are location in a different directory, then specify it here, e.g. "/public/wp"
+     */
+    public $wpCoreRootPath = "";
+
+    /**
+     *  Specifies the public path of your website relative to the root of the Valet or Herd site path.
+     *  For example, a default/vanilla install of WordPress in Herd or Valet, this should be left as a "/". But if your public files are located in a different directory, then specify it here, e.g. "/public"
+     */
+    public $rootSitePath = "";
 
     /**
      * Determine if the driver serves the request.
      */
-    public function serves(string $sitePath, string $siteName, string $uri): bool
+    public function serves(string $sitePath): bool
     {
         // Look for MULTISITE in wp-config.php. It should be there for multisite installs.
-        return file_exists($sitePath . '/public/wp-config.php') &&
-            (strpos( file_get_contents($sitePath . '/public/wp-config.php'), 'MULTISITE') !== false) &&
+        return file_exists($sitePath . $this->rootSitePath . '/wp-config.php') &&
+            (strpos(file_get_contents($sitePath . $this->rootSitePath . '/wp-config.php'), 'MULTISITE') !== false) &&
             (
                 //Double check if we are using subdomains.
-                strpos( file_get_contents($sitePath . '/public/wp-config.php'), "define('SUBDOMAIN_INSTALL',false)") ||
-                strpos( file_get_contents($sitePath . '/public/wp-config.php'), "define('SUBDOMAIN_INSTALL', false)") ||
-                strpos( file_get_contents($sitePath . '/public/wp-config.php'), "define( 'SUBDOMAIN_INSTALL', false )")
+                strpos(file_get_contents($sitePath . $this->rootSitePath . '/wp-config.php'), "define('SUBDOMAIN_INSTALL',false)") ||
+                strpos(file_get_contents($sitePath . $this->rootSitePath . '/wp-config.php'), "define('SUBDOMAIN_INSTALL', false)") ||
+                strpos(file_get_contents($sitePath . $this->rootSitePath . '/wp-config.php'), "define( 'SUBDOMAIN_INSTALL', false )")
             );
     }
 
@@ -35,28 +45,30 @@ class WordPressMultisiteSubdirectoryValetDriver extends BasicWithPublicValetDriv
 
         // If URI contains one of the main WordPress directories, and it's not a request for the Network Admin,
         // drop the subdirectory segment before routing the request
-        if ( ( stripos($uri, 'wp-admin') !== false || stripos($uri, 'wp-content') !== false || stripos($uri, 'wp-includes') !== false ) ) {
+        if ((stripos($uri, 'wp-admin') !== false || stripos($uri, 'wp-content') !== false || stripos($uri, 'wp-includes') !== false)) {
 
-            if ( stripos($uri, 'wp-admin/network') === false ) {
-                $uri = substr($uri, stripos($uri, '/wp-') );
+            if (stripos($uri, 'wp-admin/network') === false) {
+                $uri = substr($uri, stripos($uri, '/wp-'));
             }
 
-            if ( $this->wp_root !== false && file_exists($sitePath . "/public/{$this->wp_root}/wp-admin") ) {
-                $uri = "/{$this->wp_root}" . $uri;
+            if (!empty($this->wpCoreRootPath) && file_exists($sitePath . "{$this->wpCoreRootPath}/wp-admin")) {
+                $uri = "{$this->wpCoreRootPath}" . $uri;
             }
-       	}
+        }
 
         // Handle wp-cron.php properly
-        if ( stripos($uri, 'wp-cron.php') !== false ) {
-            $new_uri = substr($uri, stripos($uri, '/wp-') );
+        if (stripos($uri, 'wp-cron.php') !== false) {
+            $new_uri = substr($uri, stripos($uri, '/wp-'));
 
-            if ( file_exists( $sitePath . '/public' . $new_uri ) ) {
-                return $sitePath . "/public" . $new_uri;
+            if (file_exists($sitePath . $this->rootSitePath . $new_uri)) {
+                return $sitePath . $this->rootSitePath . $new_uri;
             }
         }
 
         return parent::frontControllerPath(
-            $sitePath, $siteName, $this->forceTrailingSlash($uri)
+            $sitePath,
+            $siteName,
+            $this->forceTrailingSlash($uri)
         );
     }
 
@@ -65,23 +77,23 @@ class WordPressMultisiteSubdirectoryValetDriver extends BasicWithPublicValetDriv
      */
     public function isStaticFile(string $sitePath, string $siteName, string $uri)/*: string|false */
     {
-    	// If the URI contains one of the main WordPress directories and it doesn't end with a slash,
-    	// drop the subdirectory from the URI and check if the file exists. If it does, return the new uri.
-        if ( stripos($uri, 'wp-admin') !== false || stripos($uri, 'wp-content') !== false || stripos($uri, 'wp-includes') !== false ) {
-        	if ( substr($uri, -1, 1) == "/" ) return false;
+        // If the URI contains one of the main WordPress directories and it doesn't end with a slash,
+        // drop the subdirectory from the URI and check if the file exists. If it does, return the new uri.
+        if (stripos($uri, 'wp-admin') !== false || stripos($uri, 'wp-content') !== false || stripos($uri, 'wp-includes') !== false) {
+            if (substr($uri, -1, 1) == "/") return false;
 
-       		$new_uri = substr($uri, stripos($uri, '/wp-') );
+            $new_uri = substr($uri, stripos($uri, '/wp-'));
 
-            if ( $this->wp_root !== false && file_exists($sitePath . "/public/{$this->wp_root}/wp-admin") ) {
-                $new_uri = "/{$this->wp_root}" . $new_uri;
+            if (!empty($this->wpCoreRootPath) && file_exists($sitePath . "{$this->wpCoreRootPath}/wp-admin")) {
+                $new_uri = "{$this->wpCoreRootPath}" . $new_uri;
             }
 
-            if ( file_exists( $sitePath . '/public' . $new_uri ) ) {
-                return $sitePath . "/public" . $new_uri;
-       		}
-       	}
+            if (file_exists($sitePath . $this->rootSitePath . $new_uri)) {
+                return $sitePath . $this->rootSitePath . $new_uri;
+            }
+        }
 
-        return parent::isStaticFile( $sitePath, $siteName, $uri );
+        return parent::isStaticFile($sitePath, $siteName, $uri);
     }
 
     /**
@@ -90,7 +102,8 @@ class WordPressMultisiteSubdirectoryValetDriver extends BasicWithPublicValetDriv
     private function forceTrailingSlash(string $uri): string
     {
         if (substr($uri, -1 * strlen('/wp-admin')) == '/wp-admin') {
-            header('Location: '.$uri.'/'); die;
+            header('Location: ' . $uri . '/');
+            die;
         }
         return $uri;
     }


### PR DESCRIPTION
These changes update the main driver and readme to enable the usage of more custom WordPress installations where their public path and/or WordPress Core installation are in different directories than a vanilla WordPress instal.