### PR TITLE
Fix subdirectory multisite wp-login.php routing and align $wpSiteUrl default

### DIFF
--- a/WordPressMultisiteSubdirectoryValetDriver.php
+++ b/WordPressMultisiteSubdirectoryValetDriver.php
@@ -50,7 +50,12 @@ class WordPressMultisiteSubdirectoryValetDriver extends BasicValetDriver
 
         // If URI contains one of the main WordPress directories, and it's not a request for the Network Admin,
         // drop the subdirectory segment before routing the request
-        if ((stripos($uri, 'wp-admin') !== false || stripos($uri, 'wp-content') !== false || stripos($uri, 'wp-includes') !== false)) {
+        if (
+            stripos($uri, 'wp-admin') !== false
+            || stripos($uri, 'wp-content') !== false
+            || stripos($uri, 'wp-includes') !== false
+            || stripos($uri, 'wp-login.php') !== false
+        ) {
 
             if (stripos($uri, 'wp-admin/network') === false) {
                 $uri = substr($uri, stripos($uri, '/wp-'));

--- a/WordPressMultisiteSubdirectoryValetDriver.php
+++ b/WordPressMultisiteSubdirectoryValetDriver.php
@@ -21,7 +21,7 @@ class WordPressMultisiteSubdirectoryValetDriver extends BasicValetDriver
     /**
      *  Specifies the URL path used to login to WordPress. In a vanilla installation of WordPress, this should be left as an empty string. But if your URL is set differently (usually defined in the WP_SITEURL constant or within the database), then specify it here (e.g. "/wp").
      */
-    public $wpSiteUrl = "/";
+    public $wpSiteUrl = "";
 
     /**
      * Determine if the driver serves the request.


### PR DESCRIPTION
### Summary
This PR fixes an edge case in Herd/Valet subdirectory multisite routing where subsite login URLs can be routed as front-end page requests instead of the core login script.

### Problem
In subdirectory multisite setups, requests like:

- https://example.test/site-a/wp-admin/
- https://example.test/site-a/wp-login.php

should resolve to core admin/login behavior for that subsite.
The driver already normalizes `wp-admin`, `wp-content`, and `wp-includes`, but not `wp-login.php` inside `frontControllerPath()`.

In Herd/Valet, `.php` handling goes through front controller resolution logic, so missing `wp-login.php` normalization can cause:

- self-redirect/login loop behavior on subsite login URLs
- reauth redirects that never reach a real login form for some flows

### Changes
1. Normalize `wp-login.php` in `frontControllerPath()`
Include `wp-login.php` in the same URI normalization branch used for `wp-admin`, `wp-content`, and `wp-includes`.

2. Align default `$wpSiteUrl` with `README` guidance
Change default from `"/"` to `""` for vanilla installs (as documented in README), reducing path concatenation ambiguity.

### Why this is safe
- `wp-login.php` is a core path in the same family as other normalized WordPress core routes.
- Existing behavior for wp-admin/network remains unchanged.
- This improves parity between documented defaults and runtime defaults.

### Reference
Observed and reproduced on Laravel Herd with WordPress multisite subdirectory install.