### PR TITLE
Fix redirect error when accessing /wp-admin without a trailing slash

### DIFF
--- a/WordPressMultisiteSubdirectoryValetDriver.php
+++ b/WordPressMultisiteSubdirectoryValetDriver.php
@@ -124,8 +124,9 @@ class WordPressMultisiteSubdirectoryValetDriver extends BasicValetDriver
      */
     private function forceTrailingSlash(string $uri): string
     {
-        if (substr($uri, -1 * strlen('/wp-admin')) == '/wp-admin') {
-            header('Location: ' . $uri . '/');
+        if (str_ends_with($uri, '/wp-admin')) {
+            $uri = rtrim($_SERVER['REQUEST_URI'] ?? $uri, '/') . '/';
+            header('Location: ' . $uri);
             die;
         }
         return $uri;

--- a/WordPressMultisiteSubdirectoryValetDriver.php
+++ b/WordPressMultisiteSubdirectoryValetDriver.php
@@ -126,7 +126,7 @@ class WordPressMultisiteSubdirectoryValetDriver extends BasicValetDriver
     {
         if (str_ends_with($uri, '/wp-admin')) {
             $uri = rtrim($_SERVER['REQUEST_URI'] ?? $uri, '/') . '/';
-            header('Location: ' . $uri);
+            header('Location: ' . $uri, true, 301);
             die;
         }
         return $uri;


### PR DESCRIPTION
Fix the ERR_UNSAFE_REDIRECT error when accessing /wp-admin without a trailing slash.
Fixes issue #7.